### PR TITLE
Add postgresql-client to container build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # 1. System packages + GitHub CLI repository
 RUN apt-get update && apt-get install -y \
-    git curl vim ca-certificates gnupg sudo \
+    git curl vim ca-certificates gnupg sudo postgresql-client \
     && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
        | gpg --dearmor -o /usr/share/keyrings/githubcli-archive-keyring.gpg \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \


### PR DESCRIPTION
## Summary

- Installs `postgresql-client` during Docker image build to enable PostgreSQL database connectivity tools

Closes #1